### PR TITLE
Photography cog added

### DIFF
--- a/Main.py
+++ b/Main.py
@@ -37,7 +37,7 @@ async def on_ready():
 	await client.change_presence(activity=discord.Game(name="#BlueLearn"))
 
 if __name__ == '__main__':
-	extensions = {'Info', 'Point', 'Fun', 'Mod', 'Welcome', 'Rule', 'Study', 'Forest', 'Announcements'} 
+	extensions = {'Info', 'Point', 'Fun', 'Mod', 'Welcome', 'Rule', 'Study', 'Forest', 'Announcements', 'Photography'} 
 	for extension in extensions:
 		try:
 			client.load_extension(extension)

--- a/Photography.py
+++ b/Photography.py
@@ -7,7 +7,7 @@ from discord.ext import commands
 
 class Photography(commands.Cog):
     """
-    Contains commands for making annoucements for BlueLearn Originals
+    Contains commands for making posts for Photography Club
     """
 
     def __init__(self, client):
@@ -16,7 +16,7 @@ class Photography(commands.Cog):
         self.EditedChannel = 825054426925498389
         self.HangoutChannel = 825055154201821244
 
-    @commands.command(name="postraw")
+    @commands.command(name="postraw", help="Posts attachment to the Raw Clicks channel")
     async def postraw(self, ctx, *, description=None):
         if ctx.channel.id == self.HangoutChannel:
             if not len(ctx.message.attachments) < 1:
@@ -42,7 +42,7 @@ class Photography(commands.Cog):
     async def postrawerror(self, ctx, error):
         await Util.ErrorHandler(ctx, error)
 
-    @commands.command(name="postedited")
+    @commands.command(name="postedited", help="Posts attachment to the Edited Pictures channel")
     async def postedited(self, ctx, *, description=None):
         if ctx.channel.id == self.HangoutChannel:
             if not len(ctx.message.attachments) < 1:
@@ -67,6 +67,8 @@ class Photography(commands.Cog):
     @postedited.error
     async def posteditederror(self, ctx, error):
         await Util.ErrorHandler(ctx, error)
+    
+
 
 def setup(client):
     client.add_cog(Photography(client))

--- a/Photography.py
+++ b/Photography.py
@@ -1,0 +1,72 @@
+import discord
+from discord.ext.commands import errors
+import Util
+import random
+from discord.ext import commands
+
+
+class Photography(commands.Cog):
+    """
+    Contains commands for making annoucements for BlueLearn Originals
+    """
+
+    def __init__(self, client):
+        self.client = client
+        self.RawChannel = 825054209338376194
+        self.EditedChannel = 825054426925498389
+        self.HangoutChannel = 825055154201821244
+
+    @commands.command(name="postraw")
+    async def postraw(self, ctx, *, description=None):
+        if ctx.channel.id == self.HangoutChannel:
+            if not len(ctx.message.attachments) < 1:
+                if not len(description) < 1:
+                    postembed = discord.Embed(title="{}".format(
+                        description), colour=random.randint(0, 0xffffff))
+                    postembed.set_image(url=ctx.message.attachments[0])
+                    postembed.set_author(name="{}".format(
+                    ctx.message.author.name), icon_url=ctx.message.author.avatar_url)
+                    sent = await self.client.get_channel(self.RawChannel).send(embed=postembed)
+                    await ctx.message.delete()
+                    await sent.add_reaction("❤")
+                else:
+                    await ctx.send("Make sure you provide a caption to your image. `?rawpost CAPTION`")
+                    await ctx.message.delete()
+            else:
+                await ctx.send("Please attatch a lovely image")
+                await ctx.message.delete()
+        else:
+            await ctx.send("You can't do that here. Please go to <#{}>".format(self.HangoutChannel))
+            await ctx.message.delete()
+    @postraw.error
+    async def postrawerror(self, ctx, error):
+        await Util.ErrorHandler(ctx, error)
+
+    @commands.command(name="postedited")
+    async def postedited(self, ctx, *, description=None):
+        if ctx.channel.id == self.HangoutChannel:
+            if not len(ctx.message.attachments) < 1:
+                if not len(description) < 1:
+                    postembed = discord.Embed(title="{}".format(
+                        description), colour=random.randint(0, 0xffffff))
+                    postembed.set_image(url=ctx.message.attachments[0])
+                    postembed.set_author(name="{}".format(
+                    ctx.message.author.name), icon_url=ctx.message.author.avatar_url)
+                    sent = await self.client.get_channel(self.EditedChannel).send(embed=postembed)
+                    await ctx.message.delete()
+                    await sent.add_reaction("❤")
+                else:
+                    await ctx.send("Make sure you provide a caption to your image. `?editedpost CAPTION`")
+                    await ctx.message.delete()
+            else:
+                await ctx.send("Please attatch a lovely image")
+                await ctx.message.delete()
+        else:
+            await ctx.send("You can't do that here. Please go to <#{}>".format(self.HangoutChannel))
+            await ctx.message.delete()
+    @postedited.error
+    async def posteditederror(self, ctx, error):
+        await Util.ErrorHandler(ctx, error)
+
+def setup(client):
+    client.add_cog(Photography(client))


### PR DESCRIPTION
fixed #10 
Basically what it does is... listens to two commands only from #hangout-zone of Photography club.

```
?postraw CAPTION
<Attatchment>
```

attachment can be image and video as well...
and it will delete the author's message (to reduce clutter) from the hangout zone and put the image as an embed with a heart reaction on #raw-pictures.
the caption is referred to as description in the code...


same for the `?postedited`

working is very similar to our suggestion system...

