### PR TITLE
Image won't expire now in photography cog.

### DIFF
--- a/Photography.py
+++ b/Photography.py
@@ -25,7 +25,7 @@ class Photography(commands.Cog):
             if not len(description) < 1:
                 postembed = discord.Embed(title="{}".format(
                     description), colour=random.randint(0, 0xffffff))
-                postembed.set_image(url=ctx.message.attachments[0])
+                postembed.set_image(url=ctx.message.attachments[0].url)
                 postembed.set_author(name="{}".format(
                 ctx.message.author.display_name), icon_url=ctx.message.author.avatar_url)
                 sent = await self.client.get_channel(self.RawChannel).send(embed=postembed)
@@ -52,7 +52,7 @@ class Photography(commands.Cog):
             if not len(description) < 1:
                 postembed = discord.Embed(title="{}".format(
                     description), colour=random.randint(0, 0xffffff))
-                postembed.set_image(url=ctx.message.attachments[0])
+                postembed.set_image(url=ctx.message.attachments[0].url)
                 postembed.set_author(name="{}".format(
                 ctx.message.author.display_name), icon_url=ctx.message.author.avatar_url)
                 sent = await self.client.get_channel(self.EditedChannel).send(embed=postembed)


### PR DESCRIPTION
Problem faced:
```
I was giving the whole attachment object as the set_image of the embed. but only URL was to be given.
```

Images on discord don't ever expire they always remain in the discord CDN server.
![image](https://user-images.githubusercontent.com/72644042/129326394-1bc3eeeb-3d61-486a-a476-0e3d9210be19.png)

